### PR TITLE
Fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const policy = {
   maxDelay: 60000
 }
 
-const url 'wss://live.example.com'
+const url = 'wss://live.example.com'
 const socket = new StableSocket(url , delegate, policy)
 socket.open()
 ```


### PR DESCRIPTION
👋 

Was reading the wonderful docs and noticed that an equal sign was missing for the `url` variable declaration.

cc @dgraham 