### PR TITLE
Set permissions for nodejs and publish workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,7 @@
 name: Node.js CI
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,3 +16,4 @@ jobs:
     - run: npm test
       env:
         CI: true
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  metadata: read
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+  metadata: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are specifying permissions for the `nodejs` and `publish` workflows. These should the least permissions needed for the workflows to run.

This PR will close the following Dependabot alerts:
- https://github.com/github/stable-socket/security/code-scanning/1
- https://github.com/github/stable-socket/security/code-scanning/2