### PR TITLE
Upgrade playwright to fix vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eslint": "^8.0.1",
         "eslint-plugin-github": "^5.0.2",
         "nodejs-websocket": "^1.7.2",
-        "playwright": "^1.48.2",
+        "playwright": "1.55.1",
         "rollup": "^4.24.0",
         "typescript": "^5.6.3",
         "vitest": "^3.2.4"
@@ -4763,13 +4763,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
-      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.2"
+        "playwright-core": "1.55.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4782,11 +4781,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
-      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^8.0.1",
     "eslint-plugin-github": "^5.0.2",
     "nodejs-websocket": "^1.7.2",
-    "playwright": "^1.48.2",
+    "playwright": "1.55.1",
     "rollup": "^4.24.0",
     "typescript": "^5.6.3",
     "vitest": "^3.2.4"


### PR DESCRIPTION
We are updating the `playwright` package version from `1.48.2` to `1.55.1`. This change is necessary to fix a security vulnerability, as described here: https://github.com/github/stable-socket/security/dependabot/65

We are relying on CI checks to verify this change.